### PR TITLE
[WIP] Add "resume" argument to harvesters

### DIFF
--- a/scrapi/harvesters/biomedcentral.py
+++ b/scrapi/harvesters/biomedcentral.py
@@ -87,7 +87,7 @@ class BiomedCentralHarvester(JSONHarvester):
             )
         }
 
-    def harvest(self, start_date=None, end_date=None):
+    def harvest(self, start_date=None, end_date=None, resume=True):
 
         start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
 
@@ -115,7 +115,7 @@ class BiomedCentralHarvester(JSONHarvester):
 
         return record_list
 
-    def get_records(self, search_url):
+    def get_records(self, search_url, resume):
         now = datetime.now()
         records = requests.get(search_url + "#{}".format(date.today()))
         page = 1
@@ -132,8 +132,11 @@ class BiomedCentralHarvester(JSONHarvester):
                     continue
                 all_records.append(record)
 
-            page += 1
-            records = requests.get(search_url + '&page={}#{}'.format(str(page), date.today()), throttle=10)
-            current_records = len(records.json()['entries'])
+            if resume:
+                page += 1
+                records = requests.get(search_url + '&page={}#{}'.format(str(page), date.today()), throttle=10)
+                current_records = len(records.json()['entries'])
+            else:
+                break
 
         return all_records

--- a/scrapi/harvesters/biomedcentral.py
+++ b/scrapi/harvesters/biomedcentral.py
@@ -96,7 +96,7 @@ class BiomedCentralHarvester(JSONHarvester):
         date_number = end_date - start_date
 
         search_url = self.URL.format(date_number.days)
-        records = self.get_records(search_url)
+        records = self.get_records(search_url, resume)
 
         record_list = []
         for record in records:

--- a/scrapi/harvesters/clinicaltrials.py
+++ b/scrapi/harvesters/clinicaltrials.py
@@ -104,7 +104,7 @@ class ClinicalTrialsHarvester(XMLHarvester):
     def namespaces(self):
         return None
 
-    def harvest(self, start_date=None, end_date=None):
+    def harvest(self, start_date=None, end_date=None, resume=True):
         """ First, get a list of all recently updated study urls,
         then get the xml one by one and save it into a list
         of docs including other information """
@@ -166,6 +166,8 @@ class ClinicalTrialsHarvester(XMLHarvester):
                 official_count += 1
                 count += 1
                 if count % 100 == 0:
+                    if not resume:
+                        break
                     logger.info("You've requested {} studies, keep going!".format(official_count))
                     count = 0
 

--- a/scrapi/harvesters/crossref.py
+++ b/scrapi/harvesters/crossref.py
@@ -106,7 +106,7 @@ class CrossRefHarvester(JSONHarvester):
             )
         }
 
-    def harvest(self, start_date=None, end_date=None):
+    def harvest(self, start_date=None, end_date=None, resume=True):
         start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
         end_date = end_date or date.today()
 
@@ -127,5 +127,8 @@ class CrossRefHarvester(JSONHarvester):
                     'docID': doc_id,
                     'filetype': 'json'
                 }))
+
+            if resume:
+                break
 
         return doc_list

--- a/scrapi/harvesters/dailyssrn.py
+++ b/scrapi/harvesters/dailyssrn.py
@@ -27,7 +27,7 @@ class DailyssrnHarvester(XMLHarvester):
         }
     }
 
-    def harvest(self, start_date=None, end_date=None):
+    def harvest(self, start_date=None, end_date=None, resume=True):
 
         url = 'http://dailyssrn.com/rss/rss-all-2.0.xml'
 

--- a/scrapi/harvesters/dataone.py
+++ b/scrapi/harvesters/dataone.py
@@ -155,12 +155,12 @@ class DataOneHarvester(XMLHarvester):
         'description': ("str[@name='abstract']/node()", single_result)
     }
 
-    def harvest(self, start_date=None, end_date=None):
+    def harvest(self, start_date=None, end_date=None, resume=True):
 
         start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
         end_date = end_date or date.today()
 
-        records = self.get_records(start_date, end_date)
+        records = self.get_records(start_date, end_date, resume)
 
         xml_list = []
         for record in records:
@@ -175,7 +175,7 @@ class DataOneHarvester(XMLHarvester):
 
         return xml_list
 
-    def get_records(self, start_date, end_date):
+    def get_records(self, start_date, end_date, resume):
         ''' helper function to get a response from the DataONE
         API, with the specified number of rows.
         Returns an etree element with results '''
@@ -199,4 +199,8 @@ class DataOneHarvester(XMLHarvester):
             docs = etree.XML(data.content).xpath('//doc')
             for doc in docs:
                 yield doc
-            n += 1000
+
+            if resume:
+                n += 1000
+            else:
+                break

--- a/scrapi/harvesters/doepages.py
+++ b/scrapi/harvesters/doepages.py
@@ -25,7 +25,7 @@ class DoepagesHarvester(XMLHarvester):
         'dcq': 'http://purl.org/dc/terms/'
     }
 
-    def harvest(self, start_date=None, end_date=None):
+    def harvest(self, start_date=None, end_date=None, resume=True):
 
         start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
         end_date = end_date or date.today()

--- a/scrapi/harvesters/figshare.py
+++ b/scrapi/harvesters/figshare.py
@@ -50,7 +50,7 @@ class FigshareHarvester(JSONHarvester):
         )
     }
 
-    def harvest(self, start_date=None, end_date=None):
+    def harvest(self, start_date=None, end_date=None, resume=True):
         """ Figshare should always have a 24 hour delay because they
         manually go through and check for test projects. Most of them
         are removed within 24 hours.
@@ -67,7 +67,7 @@ class FigshareHarvester(JSONHarvester):
             end_date.isoformat()
         )
 
-        records = self.get_records(search_url)
+        records = self.get_records(search_url, resume)
 
         record_list = []
         for record in records:
@@ -86,7 +86,7 @@ class FigshareHarvester(JSONHarvester):
 
         return record_list
 
-    def get_records(self, search_url):
+    def get_records(self, search_url, resume):
         records = requests.get(search_url)
         total_records = records.json()['items_found']
         page = 1
@@ -99,7 +99,10 @@ class FigshareHarvester(JSONHarvester):
                 if len(all_records) < total_records:
                     all_records.append(record)
 
-            page += 1
-            records = requests.get(search_url + '&page={}'.format(str(page)), throttle=3)
+            if resume:
+                page += 1
+                records = requests.get(search_url + '&page={}'.format(str(page)), throttle=3)
+            else:
+                break
 
         return all_records

--- a/scrapi/harvesters/harvarddataverse.py
+++ b/scrapi/harvesters/harvarddataverse.py
@@ -57,7 +57,7 @@ class HarvardDataverseHarvester(JSONHarvester):
         )
     }
 
-    def harvest(self, start_date=None, end_date=None):
+    def harvest(self, start_date=None, end_date=None, resume=True):
         start_date = (start_date or date.today() - timedelta(settings.DAYS_BACK)).isoformat()
         end_date = (end_date or date.today()).isoformat()
 
@@ -69,7 +69,7 @@ class HarvardDataverseHarvester(JSONHarvester):
         query.args['order'] = 'asc'
         query.args['fq'] = 'dateSort:[{}T00:00:00Z TO {}T00:00:00Z]'.format(start_date, end_date)
 
-        records = self.get_records(query.url)
+        records = self.get_records(query.url, resume)
         record_list = []
         for record in records:
             doc_id = record['global_id']
@@ -87,7 +87,7 @@ class HarvardDataverseHarvester(JSONHarvester):
 
         return record_list
 
-    def get_records(self, search_url):
+    def get_records(self, search_url, resume):
         records = requests.get(search_url)
         total_records = records.json()['data']['total_count']
         start = 0
@@ -100,6 +100,9 @@ class HarvardDataverseHarvester(JSONHarvester):
             for record in record_list:
                 all_records.append(record)
 
-            start += self.MAX_ITEMS_PER_REQUEST
+            if resume:
+                start += self.MAX_ITEMS_PER_REQUEST
+            else:
+                break
 
         return all_records

--- a/scrapi/harvesters/osf.py
+++ b/scrapi/harvesters/osf.py
@@ -85,14 +85,14 @@ class OSFHarvester(JSONHarvester):
             )
         }
 
-    def harvest(self, start_date=None, end_date=None):
+    def harvest(self, start_date=None, end_date=None, resume=True):
         # Always harvest a 2 day period starting 2 days back to honor time given
         # to contributors to cancel a public registration
         start_date = start_date or date.today() - timedelta(4)
         end_date = end_date or date.today() - timedelta(2)
 
         search_url = self.URL.format(start_date.isoformat(), end_date.isoformat())
-        records = self.get_records(search_url)
+        records = self.get_records(search_url, resume)
 
         record_list = []
         for record in records:
@@ -111,7 +111,7 @@ class OSFHarvester(JSONHarvester):
 
         return record_list
 
-    def get_records(self, search_url):
+    def get_records(self, search_url, resume):
         records = requests.get(search_url)
 
         try:
@@ -128,6 +128,10 @@ class OSFHarvester(JSONHarvester):
                 all_records.append(record)
 
             from_arg += 1000
-            records = requests.get(search_url + '&from={}'.format(str(from_arg)), throttle=10)
+
+            if resume:
+                records = requests.get(search_url + '&from={}'.format(str(from_arg)), throttle=10)
+            else:
+                break
 
         return all_records

--- a/scrapi/harvesters/plos.py
+++ b/scrapi/harvesters/plos.py
@@ -48,7 +48,7 @@ class PlosHarvester(XMLHarvester):
     MAX_ROWS_PER_REQUEST = 999
     BASE_URL = 'http://api.plos.org/search'
 
-    def fetch_rows(self, start_date, end_date):
+    def fetch_rows(self, start_date, end_date, resume):
         query = 'publication_date:[{}T00:00:00Z TO {}T00:00:00Z]'.format(start_date, end_date)
 
         resp = requests.get(self.BASE_URL, params={
@@ -72,9 +72,12 @@ class PlosHarvester(XMLHarvester):
             for doc in etree.XML(response.content).xpath('//doc'):
                 yield doc
 
-            current_row += self.MAX_ROWS_PER_REQUEST
+            if resume:
+                current_row += self.MAX_ROWS_PER_REQUEST
+            else:
+                break
 
-    def harvest(self, start_date=None, end_date=None):
+    def harvest(self, start_date=None, end_date=None, resume=True):
 
         start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
         end_date = end_date or date.today()
@@ -90,7 +93,7 @@ class PlosHarvester(XMLHarvester):
                 'docID': row.xpath("str[@name='id']")[0].text,
             })
             for row in
-            self.fetch_rows(start_date.isoformat(), end_date.isoformat())
+            self.fetch_rows(start_date.isoformat(), end_date.isoformat(), resume)
             if row.xpath("arr[@name='abstract']")
             or row.xpath("str[@name='author_display']")
         ]

--- a/scrapi/harvesters/scitech.py
+++ b/scrapi/harvesters/scitech.py
@@ -41,7 +41,7 @@ class SciTechHarvester(XMLHarvester):
 
     schema = DOESCHEMA
 
-    def harvest(self, start_date=None, end_date=None):
+    def harvest(self, start_date=None, end_date=None, resume=True):
         """A function for querying the SciTech Connect database for raw XML.
         The XML is chunked into smaller pieces, each representing data
         about an article/report. If there are multiple pages of results,
@@ -54,10 +54,10 @@ class SciTechHarvester(XMLHarvester):
                 'doc': etree.tostring(record),
                 'docID': six.u(record.xpath('dc:ostiId/node()', namespaces=self.namespaces)[0]),
             })
-            for record in self._fetch_records(start_date, end_date)
+            for record in self._fetch_records(start_date, end_date, resume)
         ]
 
-    def _fetch_records(self, start_date, end_date):
+    def _fetch_records(self, start_date, end_date, resume):
         page = 0
         morepages = True
 
@@ -76,5 +76,8 @@ class SciTechHarvester(XMLHarvester):
             for record in xml.xpath('records/record'):
                 yield record
 
-            page += 1
-            morepages = xml.xpath('//records/@morepages')[0] == 'true'
+            if resume:
+                page += 1
+                morepages = xml.xpath('//records/@morepages')[0] == 'true'
+            else:
+                break

--- a/scrapi/harvesters/springer.py
+++ b/scrapi/harvesters/springer.py
@@ -84,7 +84,7 @@ class SpringerlHarvester(JSONHarvester):
             )
         }
 
-    def harvest(self, start_date=None, end_date=None):
+    def harvest(self, start_date=None, end_date=None, resume=True):
 
         start_date = start_date or date.today() - timedelta(settings.DAYS_BACK)
         end_date = end_date or date.today()
@@ -101,7 +101,7 @@ class SpringerlHarvester(JSONHarvester):
 
             search_urls.append(self.URL.url)
 
-        records = self.get_records(search_urls)
+        records = self.get_records(search_urls, resume)
 
         return [
             RawDocument({
@@ -112,7 +112,7 @@ class SpringerlHarvester(JSONHarvester):
             }) for record in records
         ]
 
-    def get_records(self, search_urls):
+    def get_records(self, search_urls, resume):
         all_records_from_all_days = []
         for search_url in search_urls:
             records = requests.get(search_url).json()
@@ -124,7 +124,11 @@ class SpringerlHarvester(JSONHarvester):
                 record_list = records['records']
                 all_records += record_list
                 index += 100
-                records = requests.get(search_url + '&s={}'.format(str(index), throttle=10)).json()
+                if resume:
+                    records = requests.get(search_url + '&s={}'.format(str(index), throttle=10)).json()
+                else:
+                    break
+
             all_records_from_all_days = all_records_from_all_days + all_records
 
         return all_records_from_all_days

--- a/tests/test_harvesters.py
+++ b/tests/test_harvesters.py
@@ -17,7 +17,7 @@ def test_harvester(monkeypatch, harvester_name, *args, **kwargs):
     harvester = registry[harvester_name]
 
     with vcr.use_cassette('tests/vcr/{}.yaml'.format(harvester_name), match_on=['host'], record_mode='none'):
-        harvested = harvester.harvest()
+        harvested = harvester.harvest(resume=False)
         assert len(harvested) > 0
 
     normalized = list(filter(lambda x: x is not None, map(harvester.normalize, harvested[:25])))


### PR DESCRIPTION
Add arg that will only grab first page of results. This will help for both local development and test generation, as we can limit the number of results that the test harvesters harvest, and local harvesters take in.