### PR TITLE
hotfix - Fix dataone URI harvesting

### DIFF
--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -105,7 +105,7 @@ def format_tags(all_tags, sep=','):
     return list(set([six.text_type(tag.lower().strip()) for tag in tags if tag.strip()]))
 
 
-def oai_process_uris(*args):
+def oai_process_uris(*args, **kwargs):
     identifiers = []
     for arg in args:
         if isinstance(arg, list):
@@ -135,7 +135,10 @@ def oai_process_uris(*args):
                 provider_uris.append(found_url)
 
     try:
-        canonical_uri = (provider_uris + object_uris)[0]
+        if kwargs.get('use_doi') and len(object_uris) > 0:
+            canonical_uri = object_uris[0]
+        else:
+            canonical_uri = (provider_uris + object_uris)[0].strip().replace(']', '')
     except IndexError:
         raise ValueError('No Canonical URI was returned for this record.')
 

--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -106,6 +106,7 @@ def format_tags(all_tags, sep=','):
 
 
 def oai_process_uris(*args, **kwargs):
+    use_doi = kwargs.get('use_doi', False)
     identifiers = []
     for arg in args:
         if isinstance(arg, list):
@@ -135,7 +136,7 @@ def oai_process_uris(*args, **kwargs):
                 provider_uris.append(found_url)
 
     try:
-        if kwargs.get('use_doi') and len(object_uris) > 0:
+        if use_doi and len(object_uris) > 0:
             canonical_uri = object_uris[0]
         else:
             canonical_uri = (provider_uris + object_uris)[0].strip().replace(']', '')


### PR DESCRIPTION
- Add use_doi kwarg option to standard URI processor 
- Make the dataone harvester use this kwarg and use the DOIs for the canonicalUri