### PR TITLE
Update URI Processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ archive/*
 
 # Emacs edited files:
 *.*~
+
+*.sublime*

--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -122,14 +122,21 @@ def gather_identifiers(args):
     return identifiers
 
 
+def maybe_group(match):
+    '''
+    evaluates an regular expression match object, returns the group or none
+    '''
+    return match.group() if match else None
+
+
 def gather_object_uris(identifiers):
     object_uris = []
     for item in identifiers:
         if 'doi' in item.lower():
             url_doi, just_doi = URL_REGEX.search(item), DOI_REGEX.search(item)
-            url_doi = url_doi.group() if url_doi else None
-            just_doi = format_doi_as_url(just_doi.group()) if just_doi else None
-            object_uris.append(url_doi or just_doi)
+            url_doi = maybe_group(url_doi)
+            just_doi = maybe_group(just_doi)
+            object_uris.append(url_doi or format_doi_as_url(just_doi))
 
     return object_uris
 
@@ -139,8 +146,7 @@ def seperate_provider_object_uris(identifiers):
     provider_uris = []
     for item in identifiers:
 
-        found_url = URL_REGEX.search(item)
-        found_url = found_url.group() if found_url else None
+        found_url = maybe_group(URL_REGEX.search(item))
 
         if found_url:
             if 'viewcontent' in found_url:

--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -106,8 +106,9 @@ def format_tags(all_tags, sep=','):
 
 
 def format_doi_as_url(doi):
-    plain_doi = doi.replace('doi:', '').replace('DOI:', '').strip()
-    return 'http://dx.doi.org/{}'.format(plain_doi)
+    if doi:
+        plain_doi = doi.replace('doi:', '').replace('DOI:', '').strip()
+        return 'http://dx.doi.org/{}'.format(plain_doi)
 
 
 def gather_identifiers(args):

--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -105,7 +105,7 @@ def format_tags(all_tags, sep=','):
     return list(set([six.text_type(tag.lower().strip()) for tag in tags if tag.strip()]))
 
 
-def oai_process_uris(*args):
+def gather_identifiers(args):
     identifiers = []
     for arg in args:
         if isinstance(arg, list):
@@ -114,8 +114,11 @@ def oai_process_uris(*args):
         elif arg:
             identifiers.append(arg)
 
+    return identifiers
+
+
+def gather_object_uris(identifiers):
     object_uris = []
-    provider_uris = []
     for item in identifiers:
         if 'doi' in item.lower():
             try:
@@ -127,7 +130,13 @@ def oai_process_uris(*args):
                     object_uris.append('http://dx.doi.org/{}'.format(just_doi.replace('doi:', '').replace('DOI:', '').strip()))
                 except AttributeError:
                     pass
+    return object_uris
 
+
+def seperate_provider_object_uris(identifiers):
+    object_uris = gather_object_uris(identifiers)
+    provider_uris = []
+    for item in identifiers:
         try:
             found_url = URL_REGEX.search(item).group()
         except AttributeError:
@@ -138,6 +147,14 @@ def oai_process_uris(*args):
             else:
                 if 'dx.doi.org' not in found_url:
                     provider_uris.append(found_url)
+
+    return provider_uris, object_uris
+
+
+def oai_process_uris(*args):
+    identifiers = gather_identifiers(args)
+
+    provider_uris, object_uris = seperate_provider_object_uris(identifiers)
 
     try:
         canonical_uri = (provider_uris + object_uris)[0]

--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -151,13 +151,19 @@ def seperate_provider_object_uris(identifiers):
     return provider_uris, object_uris
 
 
-def oai_process_uris(*args):
-    identifiers = gather_identifiers(args)
+def oai_process_uris(*args, **kwargs):
+    use_doi = kwargs.get('use_doi', False)
 
+    identifiers = gather_identifiers(args)
     provider_uris, object_uris = seperate_provider_object_uris(identifiers)
 
     try:
-        canonical_uri = (provider_uris + object_uris)[0]
+        if use_doi:
+            for uri in object_uris:
+                if 'dx.doi.org' in uri:
+                    canonical_uri = uri
+        else:
+            canonical_uri = (provider_uris + object_uris)[0]
     except IndexError:
         raise ValueError('No Canonical URI was returned for this record.')
 

--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -105,6 +105,11 @@ def format_tags(all_tags, sep=','):
     return list(set([six.text_type(tag.lower().strip()) for tag in tags if tag.strip()]))
 
 
+def format_doi_as_url(doi):
+    plain_doi = doi.replace('doi:', '').replace('DOI:', '').strip()
+    return 'http://dx.doi.org/{}'.format(plain_doi)
+
+
 def gather_identifiers(args):
     identifiers = []
     for arg in args:
@@ -121,15 +126,11 @@ def gather_object_uris(identifiers):
     object_uris = []
     for item in identifiers:
         if 'doi' in item.lower():
-            try:
-                found_url_doi = URL_REGEX.search(item).group()
-                object_uris.append(found_url_doi)
-            except AttributeError:
-                try:
-                    just_doi = DOI_REGEX.search(item).group()
-                    object_uris.append('http://dx.doi.org/{}'.format(just_doi.replace('doi:', '').replace('DOI:', '').strip()))
-                except AttributeError:
-                    pass
+            url_doi, just_doi = URL_REGEX.search(item), DOI_REGEX.search(item)
+            url_doi = url_doi.group() if url_doi else None
+            just_doi = format_doi_as_url(just_doi.group()) if just_doi else None
+            object_uris.append(url_doi or just_doi)
+
     return object_uris
 
 
@@ -137,10 +138,10 @@ def seperate_provider_object_uris(identifiers):
     object_uris = gather_object_uris(identifiers)
     provider_uris = []
     for item in identifiers:
-        try:
-            found_url = URL_REGEX.search(item).group()
-        except AttributeError:
-            found_url = None
+
+        found_url = URL_REGEX.search(item)
+        found_url = found_url.group() if found_url else None
+
         if found_url:
             if 'viewcontent' in found_url:
                 object_uris.append(found_url)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -47,9 +47,9 @@ class TestHelpers(object):
         assert uri_dict == {
             'canonicalUri': 'http://alloutofbubblegum.com',
             'objectUris': ['http://dx.doi.org/10.whateverwhatever',
-                           'http://viewcontent.cgi/iamacoolpdf',
                            'http://dx.doi.org/10.1680/geot.11.P.130',
-                           'http://dx.doi.org/10.10.thisisarealdoi'],
+                           'http://dx.doi.org/10.10.thisisarealdoi',
+                           'http://viewcontent.cgi/iamacoolpdf'],
             'providerUris': ['http://alloutofbubblegum.com', 'http://GETTHETABLES.com']
         }
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -83,3 +83,46 @@ class TestHelpers(object):
         extracted_doi = helpers.extract_doi_from_text(text)
 
         assert extracted_doi == 'http://dx.doi.org/10.1021/woowoowoo'
+
+    def test_gather_identifiers(self):
+        identifiers = [['doi:10.whateverwhatever',
+                       'http://viewcontent.cgi/iamacoolpdf'],
+                       '451???462 [http://dx.doi.org/10.1680/geot.11.P.130]',
+                       'I am a bunch of text but I also have a doi:10.10.thisisarealdoi',
+                       ['http://bubbaray.com', 'http://devon.net']]
+
+        gathered = helpers.gather_identifiers(identifiers)
+
+        assert gathered == ['doi:10.whateverwhatever',
+                            'http://viewcontent.cgi/iamacoolpdf',
+                            '451???462 [http://dx.doi.org/10.1680/geot.11.P.130]',
+                            'I am a bunch of text but I also have a doi:10.10.thisisarealdoi',
+                            'http://bubbaray.com',
+                            'http://devon.net']
+
+    def test_gather_object_uris(self):
+        identifiers = ['doi:10.whateverwhatever',
+                       'http://viewcontent.cgi/iamacoolpdf',
+                       '451???462 [http://dx.doi.org/10.1680/geot.11.P.130]',
+                       'I am a bunch of text but I also have a doi:10.10.thisisarealdoi',
+                       'http://bubbaray.com',
+                       'http://devon.net']
+        object_uris = helpers.gather_object_uris(identifiers)
+
+        assert object_uris == [
+            'http://dx.doi.org/10.whateverwhatever',
+            'http://dx.doi.org/10.1680/geot.11.P.130',
+            'http://dx.doi.org/10.10.thisisarealdoi'
+        ]
+
+    def test_seperate_provider_object_uris(self):
+        identifiers = [
+            'http://dx.doi.org/10.whateverwhatever',
+            'http://cgi.viewcontent.apdf.pdf',
+            'http://get_the_tables.net'
+        ]
+
+        provider_uris, object_uris = helpers.seperate_provider_object_uris(identifiers)
+
+        assert provider_uris == ['http://get_the_tables.net']
+        assert object_uris == ['http://dx.doi.org/10.whateverwhatever', 'http://cgi.viewcontent.apdf.pdf']

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -126,3 +126,10 @@ class TestHelpers(object):
 
         assert provider_uris == ['http://get_the_tables.net']
         assert object_uris == ['http://dx.doi.org/10.whateverwhatever', 'http://cgi.viewcontent.apdf.pdf']
+
+    def test_format_doi_as_url(self):
+        doi1 = ' doi:10.dudleyzrule '
+        doi2 = 'DOI:10.getthetables '
+
+        assert helpers.format_doi_as_url(doi1) == 'http://dx.doi.org/10.dudleyzrule'
+        assert helpers.format_doi_as_url(doi2) == 'http://dx.doi.org/10.getthetables'

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -38,13 +38,18 @@ class TestHelpers(object):
 
     def test_extract_uris(self):
         identifiers = ['doi:10.whateverwhatever', 'http://alloutofbubblegum.com',
-                       'http://viewcontent.cgi/iamacoolpdf', 'http://GETTHETABLES.com']
+                       'http://viewcontent.cgi/iamacoolpdf', 'http://GETTHETABLES.com',
+                       'Vahedifard, F. et al. (2013). G??otechnique 63, No. 6, 451???462 [http://dx.doi.org/10.1680/geot.11.P.130] ',
+                       'I am a bunch of text but I also have a doi:10.10.thisisarealdoi']
 
         uri_dict = helpers.oai_process_uris(identifiers)
 
         assert uri_dict == {
             'canonicalUri': 'http://alloutofbubblegum.com',
-            'objectUris': ['http://dx.doi.org/10.whateverwhatever', 'http://viewcontent.cgi/iamacoolpdf'],
+            'objectUris': ['http://dx.doi.org/10.whateverwhatever',
+                           'http://viewcontent.cgi/iamacoolpdf',
+                           'http://dx.doi.org/10.1680/geot.11.P.130',
+                           'http://dx.doi.org/10.10.thisisarealdoi'],
             'providerUris': ['http://alloutofbubblegum.com', 'http://GETTHETABLES.com']
         }
 


### PR DESCRIPTION
Closes [#SHARE-54]

A harvester with a long piece of text was incorrectly parsing the URL to include a "]" at the end.

This PR fixes that, and also generally improves URL parsing to also search for dois inside of paragraphs of text.