### PR TITLE
Hotfix/recover from malformed chars

### DIFF
--- a/scrapi/base/__init__.py
+++ b/scrapi/base/__init__.py
@@ -210,7 +210,8 @@ class OAIHarvester(XMLHarvester):
 
     def normalize(self, raw_doc):
         str_result = raw_doc.get('doc')
-        result = etree.XML(str_result)
+        parser = etree.XMLParser(recover=True, encoding=self.DEFAULT_ENCODING)
+        result = etree.XML(str_result, parser=parser)
 
         if self.approved_sets:
             set_spec = result.xpath(

--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -9,7 +9,6 @@ import six
 import pytz
 import xmltodict
 from lxml import etree
-from StringIO import StringIO
 from dateutil import parser
 from pycountry import languages
 from nameparser import HumanName

--- a/scrapi/base/helpers.py
+++ b/scrapi/base/helpers.py
@@ -9,6 +9,7 @@ import six
 import pytz
 import xmltodict
 from lxml import etree
+from StringIO import StringIO
 from dateutil import parser
 from pycountry import languages
 from nameparser import HumanName
@@ -309,7 +310,8 @@ def oai_get_records_and_token(url, throttle, force, namespaces, verify):
     """
     data = requests.get(url, throttle=throttle, force=force, verify=verify)
 
-    doc = etree.XML(data.content)
+    parser = etree.XMLParser(recover=True, encoding=data.encoding)
+    doc = etree.XML(data.content, parser=parser)
 
     records = doc.xpath(
         '//ns0:record',


### PR DESCRIPTION
Update the XML parser to try and recover from malformed characters when parsing OAI-PMH content