### PR TITLE
Created filter so non-normalized documents are no longer displayed with test case

### DIFF
--- a/api/webview/views.py
+++ b/api/webview/views.py
@@ -31,7 +31,7 @@ class DocumentList(generics.ListAPIView):
         queryset = Document.objects.all().exclude(normalized=None)
         return queryset
 
-        
+
 class DocumentsFromSource(generics.ListAPIView):
     """
     List all documents from a particular source

--- a/api/webview/views.py
+++ b/api/webview/views.py
@@ -28,8 +28,10 @@ class DocumentList(generics.ListAPIView):
     def get_queryset(self):
         """ Return all documents
         """
-        queryset= Document.objects.all().exclude(normalized=None)
+        queryset = Document.objects.all().exclude(normalized=None)
         return queryset
+
+        
 class DocumentsFromSource(generics.ListAPIView):
     """
     List all documents from a particular source

--- a/api/webview/views.py
+++ b/api/webview/views.py
@@ -28,9 +28,8 @@ class DocumentList(generics.ListAPIView):
     def get_queryset(self):
         """ Return all documents
         """
-        return Document.objects.all()
-
-
+        queryset= Document.objects.all().exclude(normalized=None)
+        return queryset
 class DocumentsFromSource(generics.ListAPIView):
     """
     List all documents from a particular source
@@ -44,7 +43,7 @@ class DocumentsFromSource(generics.ListAPIView):
     def get_queryset(self):
         """ Return queryset based on source
         """
-        return Document.objects.filter(source=self.kwargs['source'])
+        return Document.objects.filter(source=self.kwargs['source']).exclude(normalized=None)
 
 
 @api_view(['GET'])

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
 from api.webview.views import DocumentList, status, institutions
+from api.webview.models import Document
 
 django.setup()
 
@@ -60,4 +61,24 @@ class APIViewTests(TestCase):
         )
         response = view(request)
         self.assertEqual(response.status_code, 200)
+    def test_exclude_non_normalized_documents(self):
+        view = DocumentList.as_view()
+        create_document(source="bad",normalized=None)
+        create_document(source="good",normalized="This is Normalized")
+        request = self.factory.get(
+            '/documents/'
+        )
+        response = view(request)        
+        self.assertNotContains(response, "bad",
+                            status_code=200)
+
+
+def create_document(source,normalized):
+        return Document.objects.create(source= source,normalized= normalized)
+
+
+
+
+
+
 


### PR DESCRIPTION
I changed the webview DocumentList view to exclude non-normalized documents from being displayed.

I wrote a test case in test_api_views in order to confirm that non-normalized documents are not being displayed.

I ran the test case and I believe the alterations are working.