### PR TITLE
Feature/formatnisttags

### DIFF
--- a/api/webview/urls.py
+++ b/api/webview/urls.py
@@ -7,7 +7,7 @@ urlpatterns = [
     url(r'^documents/status', views.status, name='status'),
     url(r'^documents/(?P<source>\w+)/$', views.DocumentsFromSource.as_view(), name='source'),
     url(r'^documents/(?P<source>[a-z]+)/(?P<docID>(.*))/$', views.document_detail, name='document_detail'),
-    url(r'^documents/(?P<from>\d{4}-\d{2}-\d{2})&(?P<until>\d{4}-\d{2}-\d{2})/$', views.DocumentsByProviderUpdatedDateTime.as_view(), name='providerupdate'),
+    url(r'^documents/from=(?P<from>\d{4}-\d{2}-\d{2})&until=(?P<until>\d{4}-\d{2}-\d{2})/$', views.DocumentsByProviderUpdatedDateTime.as_view(), name='providerupdate'),
     url(r'^institutions', views.institutions, name='institutions'),
     url(r'^robots\.txt$', include('robots.urls')),
 ]

--- a/api/webview/urls.py
+++ b/api/webview/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     url(r'^documents/status', views.status, name='status'),
     url(r'^documents/(?P<source>\w+)/$', views.DocumentsFromSource.as_view(), name='source'),
     url(r'^documents/(?P<source>[a-z]+)/(?P<docID>(.*))/$', views.document_detail, name='document_detail'),
+    url(r'^documents/(?P<from>\d{4}-\d{2}-\d{2})&(?P<until>\d{4}-\d{2}-\d{2})/$', views.DocumentsByProviderUpdatedDateTime.as_view(), name='providerupdate'),
     url(r'^institutions', views.institutions, name='institutions'),
     url(r'^robots\.txt$', include('robots.urls')),
 ]

--- a/api/webview/views.py
+++ b/api/webview/views.py
@@ -5,7 +5,7 @@ from rest_framework import permissions
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
 from django.views.decorators.clickjacking import xframe_options_exempt
-
+from dateutil.parser import parse
 from elasticsearch import Elasticsearch
 
 from scrapi import settings
@@ -39,6 +39,7 @@ class DocumentsFromSource(generics.ListAPIView):
     serializer_class = DocumentSerializer
     permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
 
+
     def perform_create(self, serializer):
         serializer.save(source=self.request.user)
 
@@ -47,6 +48,20 @@ class DocumentsFromSource(generics.ListAPIView):
         """
         return Document.objects.filter(source=self.kwargs['source']).exclude(normalized=None)
 
+class DocumentsByProviderUpdatedDateTime(generics.ListAPIView):
+    """
+    List all documents updated within specified time frame
+    """
+    serializer_class = DocumentSerializer
+    permission_classes = (permissions.IsAuthenticatedOrReadOnly,)
+    def perform_create(self, serializer):
+        serializer.save(source=self.request.user)
+    def get_queryset(self):
+        """ Return queryset based on source
+        """
+        queryset = Document.objects.all()
+        queryset = queryset.filter(providerUpdatedDateTime__gte=parse(self.kwargs['from'])).filter(providerUpdatedDateTime__lte=parse(self.kwargs['until']))
+        return queryset
 
 @api_view(['GET'])
 @xframe_options_exempt

--- a/api/webview/views.py
+++ b/api/webview/views.py
@@ -31,7 +31,7 @@ class DocumentList(generics.ListAPIView):
         queryset = Document.objects.all().exclude(normalized=None)
         return queryset
 
-        
+
 class DocumentsFromSource(generics.ListAPIView):
     """
     List all documents from a particular source

--- a/api/webview/views.py
+++ b/api/webview/views.py
@@ -28,8 +28,10 @@ class DocumentList(generics.ListAPIView):
     def get_queryset(self):
         """ Return all documents
         """
-        queryset= Document.objects.all().exclude(normalized=None)
+        queryset = Document.objects.all().exclude(normalized=None)
         return queryset
+
+        
 class DocumentsFromSource(generics.ListAPIView):
     """
     List all documents from a particular source

--- a/api/webview/views.py
+++ b/api/webview/views.py
@@ -28,9 +28,8 @@ class DocumentList(generics.ListAPIView):
     def get_queryset(self):
         """ Return all documents
         """
-        return Document.objects.all()
-
-
+        queryset= Document.objects.all().exclude(normalized=None)
+        return queryset
 class DocumentsFromSource(generics.ListAPIView):
     """
     List all documents from a particular source
@@ -44,7 +43,7 @@ class DocumentsFromSource(generics.ListAPIView):
     def get_queryset(self):
         """ Return queryset based on source
         """
-        return Document.objects.filter(source=self.kwargs['source'])
+        return Document.objects.filter(source=self.kwargs['source']).exclude(normalized=None)
 
 
 @api_view(['GET'])

--- a/scrapi/harvesters/nist.py
+++ b/scrapi/harvesters/nist.py
@@ -6,28 +6,28 @@ Example API call: https://materialsdata.nist.gov/dspace/oai/request?verb=ListRec
 from __future__ import unicode_literals
 
 from scrapi.base import OAIHarvester
-from scrapi.base.helpers import updated_schema, default_name_parser
-
+from scrapi.base.helpers import updated_schema
 
 
 class NistHarvester(OAIHarvester):
     short_name = 'nist'
     long_name = 'NIST MaterialsData'
     url = 'https://materialsdata.nist.gov'
-
     base_url = 'https://materialsdata.nist.gov/dspace/oai/request'
     property_list = ['relation', 'rights', 'identifier', 'type', 'date', 'setSpec']
     timezone_granularity = True
+
     @property
     def schema(self):
         return updated_schema(self._schema, {'subjects': ('//dc:subject/node()', format_tags)})
 
+
 def format_tags(all_tags):
     tags = []
     for tag in all_tags:
-        tag = tag.replace("Computational File Repository Categories",'')
-        tag = tag.replace("Computational File Repository",'')
-        tag = tag.replace("File Repository Categories",'')
+        tag = tag.replace("Computational File Repository Categories", '')
+        tag = tag.replace("Computational File Repository", '')
+        tag = tag.replace("File Repository Categories", '')
 
         if "::" in tag:
             tags.extend(tag.split("::"))
@@ -36,11 +36,9 @@ def format_tags(all_tags):
         elif "::" not in tag:
             tags.append(tag)
 
-
     for tag in tags:
         if "::" in tag:
             tags.remove(tag)
-        if tag =="":
+        if tag == "":
             tags.remove(tag)
     return tags
-

--- a/scrapi/harvesters/nist.py
+++ b/scrapi/harvesters/nist.py
@@ -6,6 +6,8 @@ Example API call: https://materialsdata.nist.gov/dspace/oai/request?verb=ListRec
 from __future__ import unicode_literals
 
 from scrapi.base import OAIHarvester
+from scrapi.base.helpers import updated_schema, default_name_parser
+
 
 
 class NistHarvester(OAIHarvester):
@@ -16,3 +18,29 @@ class NistHarvester(OAIHarvester):
     base_url = 'https://materialsdata.nist.gov/dspace/oai/request'
     property_list = ['relation', 'rights', 'identifier', 'type', 'date', 'setSpec']
     timezone_granularity = True
+    @property
+    def schema(self):
+        return updated_schema(self._schema, {'subjects': ('//dc:subject/node()', format_tags)})
+
+def format_tags(all_tags):
+    tags = []
+    for tag in all_tags:
+        tag = tag.replace("Computational File Repository Categories",'')
+        tag = tag.replace("Computational File Repository",'')
+        tag = tag.replace("File Repository Categories",'')
+
+        if "::" in tag:
+            tags.extend(tag.split("::"))
+        if "," in tag:
+            tags.extend(tag.split(","))
+        elif "::" not in tag:
+            tags.append(tag)
+
+
+    for tag in tags:
+        if "::" in tag:
+            tags.remove(tag)
+        if tag =="":
+            tags.remove(tag)
+    return tags
+

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -2,10 +2,10 @@ import os
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.api.settings")
 
 import django
-from django.test import TestCase
-from rest_framework.test import APIRequestFactory
-
-from api.webview.views import DocumentList, status, institutions
+from django.test import TestCase 
+from rest_framework.test import APIRequestFactory, APITestCase, APIClient, force_authenticate
+from dateutil.parser import parse
+from api.webview.views import DocumentList, status, institutions, DocumentsByProviderUpdatedDateTime
 from api.webview.models import Document
 
 django.setup()
@@ -71,8 +71,26 @@ class APIViewTests(TestCase):
         response = view(request)        
         self.assertNotContains(response, "bad",
                             status_code=200)
+        self.assertContains(response, "good", status_code=200)
+        print(response)
 
 
+class APIViewTests2(APITestCase):
+
+    def test_query_search_by_providerupdatedtime(self):
+        view = DocumentsByProviderUpdatedDateTime.as_view()
+        create_new_document(source = "tooearly",providerUpdatedDateTime= parse("2012-01-01"))
+        create_new_document(source = "rightontime", providerUpdatedDateTime= parse("2013-01-05"))
+        create_new_document(source= "toolate", providerUpdatedDateTime = parse("2015-01-01"))
+        response = self.client.get('/documents/2013-01-01&2014-12-30/', kwargs= {'from':"2013-01-01",'until':'2014-12-30'})
+        force_authenticate(response)
+        self.assertNotContains(response, "tooearly", status_code=200)
+        self.assertContains(response, "rightontime", status_code=200)
+        self.assertNotContains(response, "toolate", status_code =200)
+
+
+def create_new_document(source,providerUpdatedDateTime):
+        return Document.objects.create(source = source, providerUpdatedDateTime = providerUpdatedDateTime)
 def create_document(source,normalized):
         return Document.objects.create(source= source,normalized= normalized)
 

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -82,7 +82,7 @@ class APIViewTests2(APITestCase):
         create_new_document(source = "tooearly",providerUpdatedDateTime= parse("2012-01-01"))
         create_new_document(source = "rightontime", providerUpdatedDateTime= parse("2013-01-05"))
         create_new_document(source= "toolate", providerUpdatedDateTime = parse("2015-01-01"))
-        response = self.client.get('/documents/2013-01-01&2014-12-30/', kwargs= {'from':"2013-01-01",'until':'2014-12-30'})
+        response = self.client.get('/documents/from=2013-01-01&until=2014-12-30/', kwargs= {'from':"2013-01-01",'until':'2014-12-30'})
         force_authenticate(response)
         self.assertNotContains(response, "tooearly", status_code=200)
         self.assertContains(response, "rightontime", status_code=200)

--- a/tests/test_api_views.py
+++ b/tests/test_api_views.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
 from api.webview.views import DocumentList, status, institutions
+from api.webview.models import Document
 
 django.setup()
 
@@ -60,4 +61,24 @@ class APIViewTests(TestCase):
         )
         response = view(request)
         self.assertEqual(response.status_code, 200)
+    def test_exclude_non_normalized_documents(self):
+        view = DocumentList.as_view()
+        create_document(source="bad",normalized=None)
+        create_document(source="good",normalized="This is Normalized")
+        request = self.factory.get(
+            '/documents/'
+        )
+        response = view(request)        
+        self.assertNotContains(response, "bad",
+                            status_code=200)
+
+
+def create_document(source,normalized):
+        return Document.objects.create(source= source,normalized= normalized)
+
+
+
+
+
+
 


### PR DESCRIPTION
I altered the schema for the nist harvester. Previously the harvester was extracting necessary text such as "computational file repository categories" to the strings, and separate tags were concatenated by "::".

I wrote a new format_tags method to fix these issues and the tags (subjects) should be displaying correctly without the above described issues.