### PR TITLE
Fix django settings import conflict with OSF

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -189,6 +189,7 @@ def worker(loglevel='INFO', hostname='%h', autoreload=False):
 @task
 def harvester(harvester_name, async=False, start=None, end=None):
     ''' Runs a specific harvester '''
+    os.environ['DJANGO_SETTINGS_MODULE'] = 'api.api.settings'
     from scrapi import settings
     settings.CELERY_ALWAYS_EAGER = not async
     from scrapi import registry


### PR DESCRIPTION
Django env variable is overwritten in the OSF and causes local scrapi errors when running scrapi and the OSF one after another... might be a better way to fix this, but this seems to be how the OSF sets the variable. 